### PR TITLE
fixed wrong version detection method for golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ generated/
 bin/*
 gin-bin
 .idea/
+.vscode/

--- a/genny/rx/go_checks.go
+++ b/genny/rx/go_checks.go
@@ -3,7 +3,6 @@ package rx
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/gobuffalo/genny/v2"
@@ -19,10 +18,14 @@ func goCheck(opts *Options) *genny.Generator {
 		Minimum: GoMinimums,
 		Partial: "go/_help.plush",
 		Version: func(r *genny.Runner) (string, error) {
-			v, ok := opts.Versions.Load("go")
-			if !ok {
-				v = runtime.Version()
+			if v, ok := opts.Versions.Load("go"); ok {
+				return v, nil
 			}
+			v, err := cmdVersion(r, "go", "version")
+			if err != nil {
+				return "", err
+			}
+			v = strings.Split(v, " ")[2] // go version go1.17.8 linux/amd64
 			return strings.TrimPrefix(v, "go"), nil
 		},
 	}

--- a/genny/rx/options.go
+++ b/genny/rx/options.go
@@ -2,7 +2,6 @@ package rx
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/gobuffalo/meta"
 	"github.com/gobuffalo/plush/v4"
@@ -24,9 +23,6 @@ func (opts *Options) Validate() error {
 	}
 	if opts.Out.Writer == nil {
 		opts.Out = NewWriter(os.Stdout)
-	}
-	if _, ok := opts.Versions.Load("go"); !ok {
-		opts.Versions.Store("go", runtime.Version())
 	}
 	return nil
 }


### PR DESCRIPTION
I just found the old issue #6 and fixed the issue. `runtime.Version()` is not feasible here, and the "Your Go version" should be detected in live method.

fixes #6