### PR TITLE
reconfigure goreleaser action with a new PAT, finally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,21 +8,20 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
     steps:
-      -
-        name: Set up Go 1.16
-        uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
         with:
-          go-version: 1.16
-        id: go
-      -
-        name: Checkout Code
-        uses: actions/checkout@master
-      -
-        name: Run GoReleaser
-        env:
-          GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
-        uses: goreleaser/goreleaser-action@v1
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_PAT }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,5 @@
 builds:
-  -
-    main: ./main.go
+  - main: ./main.go
     env:
       - CGO_ENABLED=0
     ldflags:
@@ -18,8 +17,7 @@ builds:
       - 6
       - 7
 archives:
-  -
-    replacements:
+  - replacements:
       '386': i386
       darwin: Darwin
       linux: Linux
@@ -36,8 +34,7 @@ changelog:
       - '^docs:'
       - '^test:'
 brews:
-  -
-    name: 'clara'
+  - name: 'clara'
     tap:
       owner: 'gobuffalo'
       name: 'homebrew-tap'

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // Version of main
-var Version = "v2.0.5"
+var Version = "v2.0.9"


### PR DESCRIPTION
I found the release (with goreleaser) workflow did not work for this repository yesterday and tried to make it simple.

* failed to remove a custom token but use the default token --> failed because of homebrew tap in a separate repo
* configured it to use org level token --> works fine

(deleted workflow logs, commits, pre-releases for testing)